### PR TITLE
Add support for leveraging browser caching

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -57,6 +57,16 @@ map $scheme $proxy_x_forwarded_ssl {
   https on;
 }
 
+# Expires map
+map $sent_http_content_type $expires {
+  default                   off;
+  ~application/             30d;
+  ~text/                    30d;
+  ~audio/                   365d;
+  ~video/                   365d;
+  ~image/                   365d;
+}
+
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
@@ -210,6 +220,8 @@ server {
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
+	expires $expires;
+
 	{{ if eq $network_tag "internal" }}
 	# Only allow traffic from internal clients
 	include /etc/nginx/network_internal.conf;
@@ -307,6 +319,8 @@ server {
 	listen [::]:80 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
+
+	expires $expires;
 
 	{{ if eq $network_tag "internal" }}
 	# Only allow traffic from internal clients


### PR DESCRIPTION
@lucasayres: Benefits of leveraging browser caching:
- Primary benefit is speeding up the website because static files will be served by your browser. It saves internet data of visitors. It also saves bandwidth for webserver and decreases server load. It simply decreases the number of HTTP requests.
- Score on Google PageSpeed Insights and GTmetrix.