### PR TITLE
Add client_max_body_size directive

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -205,6 +205,7 @@ server {
 server {
 	server_name {{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
+	client_max_body_size 0;
 	{{ if $enable_ipv6 }}
 	listen [::]:443 ssl http2 {{ $default_server }};
 	{{ end }}
@@ -303,6 +304,7 @@ server {
 server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
+	client_max_body_size 0;
 	{{ if $enable_ipv6 }}
 	listen [::]:80 {{ $default_server }};
 	{{ end }}


### PR DESCRIPTION
This directive sets the maximum allowed size of the client request body, specified in the `Content-Length` request header field. If the size in a request exceeds the configured value, the `413 Request Entity Too Large` error is returned to the client. Please be aware that browsers cannot correctly display this error. Setting `size` to `0` disables checking of client request body size.

@ipepe: I think that this nginx proxy configuration should be as transparent as possible. And not setting `client_max_body_size` leaves it on default with `1m` value. I suggest that it should be `client_max_body_size 0;`.