### PR TITLE
Add VIRTUAL_HOST_ALIAS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,31 @@ If you need to support multiple virtual hosts for a container, you can separate 
 
 You can also use wildcards at the beginning and the end of host name, like `*.bar.com` or `foo.bar.*`. Or even a regular expression, which can be very useful in conjunction with a wildcard DNS service like [xip.io](http://xip.io), using `~^foo\.bar\..*\.xip\.io` will match `foo.bar.127.0.0.1.xip.io`, `foo.bar.10.0.2.2.xip.io` and all other given IPs. More information about this topic can be found in the nginx documentation about [`server_names`](http://nginx.org/en/docs/http/server_names.html).
 
+### Virtual Host Aliases
+
+You can add aliases that will redirect (301) to the first entry in `VIRTUAL_HOST` by adding the `VIRTUAL_HOST_ALIAS` env var:
+
+    $ docker run -e VIRTUAL_HOST=example.com -e VIRTUAL_HOST_ALIAS=www.example.com,old.example.com ...
+
+This will setup the following redirects:
+- `http://www.example.com` &#8594; `http://example.com`
+- `http://old.example.com` &#8594; `http://example.com`
+
+If you are using [letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) for SSL support, then you would run:
+
+    $ docker run    -e VIRTUAL_HOST=example.com \
+                    -e VIRTUAL_HOST_ALIAS=www.example.com,old.example.com
+                    -e LETSENCRYPT_HOST=example.com,www.example.com,old.example.com
+                    ...
+
+This will setup the following redirects:
+ - `http://example.com` &#8594; `https://example.com`
+ - `http://www.example.com` &#8594; `https://www.example.com` &#8594; `https://example.com`
+ - `http://old.example.com` &#8594; `http://example.com` &#8594; `https://example.com`
+ - `https://www.example.com` &#8594; `https://example.com`
+ - `https://old.example.com` &#8594; `https://example.com`
+
+
 ### Multiple Networks
 
 With the addition of [overlay networking](https://docs.docker.com/engine/userguide/networking/get-started-overlay/) in Docker 1.9, your `nginx-proxy` container may need to connect to backend containers on multiple networks. By default, if you don't pass the `--net` flag when your `nginx-proxy` container is created, it will only be attached to the default `bridge` network. This means that it will not be able to connect to containers on networks other than `bridge`.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ If you are using [letsencrypt-nginx-proxy-companion](https://github.com/JrCs/doc
 
 This will setup the following redirects:
  - `http://example.com` &#8594; `https://example.com`
- - `http://www.example.com` &#8594; `https://www.example.com` &#8594; `https://example.com`
- - `http://old.example.com` &#8594; `http://example.com` &#8594; `https://example.com`
+ - `http://www.example.com` &#8594; `https://example.com`
+ - `http://old.example.com` &#8594; `https://example.com`
  - `https://www.example.com` &#8594; `https://example.com`
  - `https://old.example.com` &#8594; `https://example.com`
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -383,17 +383,20 @@ server {
 # VIRTUAL_HOST_ALIAS
 {{ range $host_alias, $containers := groupByMulti $ "Env.VIRTUAL_HOST_ALIAS" "," }}
 
+{{ $host_alias := trim $host_alias }}
+
 {{ $first_host := (first (groupByKeys $containers "Env.VIRTUAL_HOST")) }}
+{{ $first_host := trim $first_host }}
+
 # First Host {{ $first_host }}
 
 #Alias:  {{ $host_alias }}
-server {
-  server_name {{ $host_alias }};
-  return 301 $scheme://{{ $first_host }}$request_uri;
-}
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host_alias "" $default_host "default_server") $host_alias }}
+
+{{/* Get the NETWORK_ACCESS defined by containers w/ the same vhost, falling back to "external" */}}
+{{ $network_tag := or (first (groupByKeys $containers "Env.NETWORK_ACCESS")) "external" }}
 
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
@@ -421,6 +424,17 @@ server {
 
 {{ if $is_https }}
 
+{{ if eq $https_method "redirect" }}
+server {
+	server_name {{ $host_alias }};
+	listen 80 {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:80 {{ $default_server }};
+	{{ end }}
+	access_log /var/log/nginx/access.log vhost;
+	return 301 https://{{ $first_host }}$request_uri;
+}
+{{ end }}
 server {
 	server_name {{ $host_alias }};
 	listen 443 ssl http2 {{ $default_server }};
@@ -463,4 +477,44 @@ server {
 
 {{ end }}
 
+{{ if or (not $is_https) (eq $https_method "noredirect") }}
+
+server {
+	server_name {{ $host_alias }};
+	listen 80 {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:80 {{ $default_server }};
+	{{ end }}
+	access_log /var/log/nginx/access.log vhost;
+
+	{{ if eq $network_tag "internal" }}
+	# Only allow traffic from internal clients
+	include /etc/nginx/network_internal.conf;
+	{{ end }}
+
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host_alias)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host_alias }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	return 301 http://{{ $first_host }}$request_uri;
+}
+
+{{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+server {
+	server_name {{ $host_alias }};
+	listen 443 ssl http2 {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:443 ssl http2 {{ $default_server }};
+	{{ end }}
+	access_log /var/log/nginx/access.log vhost;
+	return 500;
+
+	ssl_certificate /etc/nginx/certs/default.crt;
+	ssl_certificate_key /etc/nginx/certs/default.key;
+}
+{{ end }}
+
+{{ end }}
 {{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -379,3 +379,88 @@ server {
 
 {{ end }}
 {{ end }}
+
+# VIRTUAL_HOST_ALIAS
+{{ range $host_alias, $containers := groupByMulti $ "Env.VIRTUAL_HOST_ALIAS" "," }}
+
+{{ $first_host := (first (groupByKeys $containers "Env.VIRTUAL_HOST")) }}
+# First Host {{ $first_host }}
+
+#Alias:  {{ $host_alias }}
+server {
+  server_name {{ $host_alias }};
+  return 301 $scheme://{{ $first_host }}$request_uri;
+}
+
+{{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
+{{ $default_server := index (dict $host_alias "" $default_host "default_server") $host_alias }}
+
+{{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
+{{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
+
+{{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
+{{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}
+
+{{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
+{{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) "max-age=31536000" }}
+
+{{/* Get the first cert name defined by containers w/ the same vhost */}}
+{{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
+
+{{/* Get the best matching cert  by name for the vhost. */}}
+{{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host_alias))}}
+
+{{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
+{{ $vhostCert := trimSuffix ".crt" $vhostCert }}
+{{ $vhostCert := trimSuffix ".key" $vhostCert }}
+
+{{/* Use the cert specified on the container or fallback to the best vhost match */}}
+{{ $cert := (coalesce $certName $vhostCert) }}
+
+{{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
+
+{{ if $is_https }}
+
+server {
+	server_name {{ $host_alias }};
+	listen 443 ssl http2 {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:443 ssl http2 {{ $default_server }};
+	{{ end }}
+	access_log /var/log/nginx/access.log vhost;
+
+	{{ template "ssl_policy" (dict "ssl_policy" $ssl_policy) }}
+
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+
+	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
+	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
+
+	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
+	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
+	{{ end }}
+
+	{{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
+	{{ end }}
+
+	{{ if (not (or (eq $https_method "noredirect") (eq $hsts "off"))) }}
+	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
+	{{ end }}
+
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host_alias)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host_alias }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	return 301 https://{{ $first_host }}$request_uri;
+}
+
+{{ end }}
+
+{{ end }}


### PR DESCRIPTION
@dannycarrera: This feature adds support for `VIRTUAL_HOST_ALIAS` and is in response to issues #180, #958 and #1204.

You can add aliases that will redirect (301) to the first entry in `VIRTUAL_HOST` by adding the `VIRTUAL_HOST_ALIAS` env var:

```
$ docker run -e VIRTUAL_HOST=example.com -e VIRTUAL_HOST_ALIAS=www.example.com,old.example.com ...
```

This will setup the following redirects:
- `http://www.example.com` → `http://example.com`
- `http://old.example.com` → `http://example.com`

If you are using [letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) for SSL support, then you would run:

```
$ docker run -e VIRTUAL_HOST=example.com \
             -e VIRTUAL_HOST_ALIAS=www.example.com,old.example.com
             -e LETSENCRYPT_HOST=example.com,www.example.com,old.example.com
```

This will setup the following redirects:
- `http://example.com` → `https://example.com`
- `http://www.example.com` → `https://example.com`
- `http://old.example.com` → `https://example.com`
- `https://www.example.com` → `https://example.com`
- `https://old.example.com` → `https://example.com`
